### PR TITLE
Use os.Exit() instead of panic().

### DIFF
--- a/dnmgr/dnmgr/main.go
+++ b/dnmgr/dnmgr/main.go
@@ -53,7 +53,8 @@ func main() {
 		}
 		profile, sk, err := client.NewProfile(nil, nil)
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "creating a new profile failed: %s\n", err);
+			os.Exit(1)
 		}
 		if err := dnmgr.Register(sk, profile, name, invite, "", nil); err != nil {
 			fmt.Fprintf(os.Stderr, "registration failed: %s\n", err)


### PR DESCRIPTION
There are no defered functions in the client.NewProfile() call, so why is the panic() call needed.