### PR TITLE
Write public and private key into different files.

### DIFF
--- a/utils/mkkey/mkkey.go
+++ b/utils/mkkey/mkkey.go
@@ -41,7 +41,7 @@ func main() {
 	pkfile := path.Join(dir, PUBLIC_KEY)
 
 	if _, err := os.Stat(skfile); err == nil {
-		fmt.Fprintf(os.Stderr, "%s already exists\n", pkfile)
+		fmt.Fprintf(os.Stderr, "%s already exists\n", skfile)
 		os.Exit(1)
 	}
 	if _, err := os.Stat(pkfile); err == nil {

--- a/utils/mkkey/mkkey.go
+++ b/utils/mkkey/mkkey.go
@@ -18,22 +18,50 @@ import (
 	"crypto/rand"
 	"github.com/agl/ed25519"
 	. "github.com/andres-erbsen/dename/protocol"
+	"io/ioutil"
+	"log"
 	"fmt"
+	"path"
 	"os"
 )
 
+const PRIVATE_KEY string = "private_key"
+const PUBLIC_KEY string = "public_key"
+
 func main() {
+	var dir string
+
+	if len(os.Args) < 2 {
+		dir = "."
+	} else {
+		dir = os.Args[1]
+	}
+
+	privfile := path.Join(dir, PRIVATE_KEY)
+	pubfile := path.Join(dir, PUBLIC_KEY)
+
+	if _, err := os.Stat(privfile); err == nil {
+		fmt.Fprintf(os.Stderr, "%s already exists\n", privfile)
+		os.Exit(1)
+	}
+	if _, err := os.Stat(pubfile); err == nil {
+		fmt.Fprintf(os.Stderr, "%s already exists\n", pubfile)
+		os.Exit(1)
+	}
+
 	pk, sk, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to create ed25519 keys")
+		log.Fatal(err)
 		os.Exit(1)
 	}
-	if _, err := os.Stderr.Write(sk[:]); err != nil {
-		fmt.Fprintf(os.Stderr, "unable to write secret key")
+	if err := ioutil.WriteFile(privfile, sk[:], 0600); err != nil {
+		log.Fatal(err)
 		os.Exit(1)
 	}
-	if _, err := os.Stdout.Write(PBEncode(&Profile_PublicKey{Ed25519: pk[:]})); err != nil {
-		fmt.Fprintf(os.Stderr, "unable to write public key")
+
+	data := PBEncode(&Profile_PublicKey{Ed25519: pk[:]})
+	if err := ioutil.WriteFile(pubfile, data, 0644); err != nil {
+		log.Fatal(err)
 		os.Exit(1)
 	}
 }

--- a/utils/mkkey/mkkey.go
+++ b/utils/mkkey/mkkey.go
@@ -25,7 +25,7 @@ import (
 	"os"
 )
 
-const PRIVATE_KEY string = "private_key"
+const SECRET_KEY string = "secret_key"
 const PUBLIC_KEY string = "public_key"
 
 func main() {
@@ -37,15 +37,15 @@ func main() {
 		dir = os.Args[1]
 	}
 
-	privfile := path.Join(dir, PRIVATE_KEY)
-	pubfile := path.Join(dir, PUBLIC_KEY)
+	skfile := path.Join(dir, SECRET_KEY)
+	pkfile := path.Join(dir, PUBLIC_KEY)
 
-	if _, err := os.Stat(privfile); err == nil {
-		fmt.Fprintf(os.Stderr, "%s already exists\n", privfile)
+	if _, err := os.Stat(skfile); err == nil {
+		fmt.Fprintf(os.Stderr, "%s already exists\n", pkfile)
 		os.Exit(1)
 	}
-	if _, err := os.Stat(pubfile); err == nil {
-		fmt.Fprintf(os.Stderr, "%s already exists\n", pubfile)
+	if _, err := os.Stat(pkfile); err == nil {
+		fmt.Fprintf(os.Stderr, "%s already exists\n", pkfile)
 		os.Exit(1)
 	}
 
@@ -54,13 +54,13 @@ func main() {
 		log.Fatal(err)
 		os.Exit(1)
 	}
-	if err := ioutil.WriteFile(privfile, sk[:], 0600); err != nil {
+	if err := ioutil.WriteFile(skfile, sk[:], 0600); err != nil {
 		log.Fatal(err)
 		os.Exit(1)
 	}
 
 	data := PBEncode(&Profile_PublicKey{Ed25519: pk[:]})
-	if err := ioutil.WriteFile(pubfile, data, 0644); err != nil {
+	if err := ioutil.WriteFile(pkfile, data, 0644); err != nil {
 		log.Fatal(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
This version writes the public and private key into different files and set the correct permissions.
It will protect keys that already exist against overriding.

The chatterbox changes will follow.