### PR TITLE
Added unset command as the inverse function of set.

### DIFF
--- a/client/profile.go
+++ b/client/profile.go
@@ -83,6 +83,10 @@ func SetProfileField(profile *Profile, field int32, value []byte) error {
 	return proto.SetExtension(profile, profileField(field), value)
 }
 
+func ClearProfileField(profile *Profile, field int32) {
+	proto.ClearExtension(profile, profileField(field))
+}
+
 func NewProfile(rnd io.Reader, expirationTime *time.Time) (profile *Profile,
 	sk *[ed25519.PrivateKeySize]byte, err error) {
 	if rnd == nil {

--- a/dnmgr/dnmgr/main.go
+++ b/dnmgr/dnmgr/main.go
@@ -33,8 +33,10 @@ func usageAndExit(str string) {
 		"\t\t                             If the value is empty, stdin will be used. Possible\n"+
 		"\t\t                             fields are: bitcoin, dename, dename-transport, dns,\n"+
 		"\t\t                             email, gpg, http, jabber, openpgp, otr, pgp, ssh,\n"+
-		"\t\t                             ssh-host, textsecure, tor, web, or xmpp.\n",
-		os.Args[0], os.Args[0])
+		"\t\t                             ssh-host, textsecure, tor, web, or xmpp.\n"+
+		"\t%s unset <name> <field>         # unset a field\n"+
+		"\t\t                             The possible fields are the same as for the set command\n",
+		os.Args[0], os.Args[0], os.Args[0])
 
 	os.Exit(1)
 }
@@ -65,7 +67,6 @@ func main() {
 			os.Exit(1)
 		}
 	case "set":
-
 		var name, fieldName string
 		var value []byte
 		if len(args) == 2 || len(args) == 3 {
@@ -93,6 +94,24 @@ func main() {
 			}
 		}
 		if err := dnmgr.SetProfileField(name, fieldNumber, value, "", nil); err != nil {
+			fmt.Fprintf(os.Stderr, "operation failed: %s\n", err)
+			os.Exit(1)
+		}
+	case "unset":
+		var name, fieldName string
+		if len(args) == 2 {
+			name, fieldName = args[0], args[1]
+		} else {
+			usageAndExit("")
+		}
+		if _, _, err := dnmgr.LoadLocalProfile(name, ""); err != nil {
+			usageAndExit("profile not found for name:  " + name)
+		}
+		fieldNumber, err := client.FieldByName(fieldName)
+		if err != nil {
+			usageAndExit("unknown field: " + fieldName)
+		}
+		if err := dnmgr.ClearProfileField(name, fieldNumber, "", nil); err != nil {
 			fmt.Fprintf(os.Stderr, "operation failed: %s\n", err)
 			os.Exit(1)
 		}

--- a/dnmgr/persistence.go
+++ b/dnmgr/persistence.go
@@ -164,3 +164,37 @@ func SetProfileField(name string, field int32, value []byte, configDir string, c
 	}
 	return ioutil.WriteFile(filepath.Join(configDir, filename(name), "profile"), PBEncode(profile), 0600)
 }
+
+// ClearProfileField downloads the profile for name, clears the given field
+// and uses sk to remap the name to the old profile. The local copy of the
+// profile is ignored and overwritten. The version number is incremented by one
+// and the expiration time is set to 364 days into the future if it is earlier.
+func ClearProfileField(name string, field int32, configDir string, client *dnmc.Client) error {
+	configDir, client, err := dirAndClient(configDir, client)
+	if err != nil {
+		return fmt.Errorf("failed to load config file: %v", err)
+	}
+	sk, _, err := LoadLocalProfile(name, configDir)
+	if err != nil {
+		return err
+	}
+	profile, err := client.Lookup(name)
+	if err != nil && !dnmc.IsErrOutOfDate(err) {
+		return err
+	}
+
+	version := profile.GetVersion()
+	profile.Version = new(uint64)
+	*profile.Version = version + 1
+	expire := uint64(time.Now().Add(MAX_VALIDITY_PERIOD*time.Second - 24*time.Hour).Unix())
+	if profile.GetExpirationTime() < expire {
+		profile.ExpirationTime = &expire
+	}
+
+	dnmc.ClearProfileField(profile, field)
+	if err := client.Modify(sk, name, profile); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filepath.Join(configDir, filename(name), "profile"), PBEncode(profile), 0600)
+}
+


### PR DESCRIPTION
This commit introduces the unset command for dnmgr. It is the inverse operation for set and removes a field. Instead of just setting it to "", in order to clean it.